### PR TITLE
Adding my blog to the list of blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ _Links to various users of Home Assistant that regularly publish Home Assistant 
 * [Smart Home Hobby](https://smarthomehobby.com/) - Features budget friendly guides and information.
 * [Self Hosted Home](https://selfhostedhome.com/) - Articles on DIY home automation projects and self hosted services.
 * [Tinkering with Home Automation](https://blog.ceard.tech/) - Tinkerer's blog and guides.
+* [HomeTechHacker](https://HomeTechHacker) - DIY Smarthome instructions, reviews, and advice.
 
 ### YouTube Channels
 


### PR DESCRIPTION

# Describe the proposed change

Hi. I know this is self-promotion, but I like to think the information on my blog is useful in helping Home Assistant users and promoting Home Assistant. It has articles on building and improving smarthomes, using and configuring Home Assistant, and reviews of devices that integrate with HA, and I will continue to add more of those types of articles.

If it is more appropriate to link directly to my smarthome or Home Assistant category I'm happy to do that. Thank you.

BTW, I've never really used Github for anything other viewing other people's projects, so I hope I'm doing all this right!

## The link

https://HomeTechHacker.com
## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
